### PR TITLE
✏️ Adds 'deploy' job to Github Action

### DIFF
--- a/.github/workflows/elm.yml
+++ b/.github/workflows/elm.yml
@@ -1,17 +1,33 @@
-name: Elm CI
+name: Elm CI for running tests and deploying to Github Pages
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+  push:
+    branches:
+      - master
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. However, do NOT cancel in-progress runs as we
+# want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  build:
-
-    name: Build and test
+  test:
+    name: Test
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,6 +47,48 @@ jobs:
 
       - name: Install and run elm-test
         run: |
+          echo "Running elm-format and elm-test..."
           npm install
           npm run format
           npm run test
+
+  deploy:
+    name: Deploy to Github Pages
+    runs-on: ubuntu-latest
+
+    needs: test
+    if: ${{ github.ref == 'refs/heads/master' }}
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Elm
+        uses: jorelali/setup-elm@v6
+        with:
+          elm-version: 0.19.1
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.18'
+
+      - name: Compile and minimize project
+        run: ./build.sh
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+      - name: Deploy to dragonwasrobot.com/brainfuck
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,6 @@
         <link href="style.css"
               rel="stylesheet"
               type="text/css" />
-        <script src="https://unpkg.com/elm-canvas@2.2.3/elm-canvas.js"></script>
         <script src="elm.min.js" type="text/javascript"></script>
     </head>
 


### PR DESCRIPTION
The 'deploy' job archives the `docs` folder and publishes it via Github Pages, thus replacing the legacy-mode for deploying pages in Github.